### PR TITLE
fix: update dependency origin

### DIFF
--- a/frontend/frontend-platformio/.vscode/extensions.json
+++ b/frontend/frontend-platformio/.vscode/extensions.json
@@ -1,7 +1,10 @@
 {
-	// See http://go.microsoft.com/fwlink/?LinkId=827846
-	// for the documentation about the extensions.json format
-	"recommendations": [
-		"platformio.platformio-ide"
-	]
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
 }

--- a/frontend/frontend-platformio/platformio.ini
+++ b/frontend/frontend-platformio/platformio.ini
@@ -7,14 +7,16 @@
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
+[platformio]
+default_envs = nanoatmega328
 
 [env:nanoatmega328]
 platform = atmelavr
-board = nanoatmega328 
+board = nanoatmega328
 framework = arduino
-lib_deps = 
-    MFRC522@1.3.6
-    jm_Wire@1.0.1
-    jm_Scheduler@1.0.4
-    Keypad@3.1.1
-    jm_LiquidCrystal_I2C@1.0.0
+lib_deps =
+    git+https://github.com/miguelbalboa/rfid#1.3.6
+    git+https://github.com/jmparatte/jm_Wire#1.0.1
+    git+https://github.com/jmparatte/jm_Scheduler#1.0.4
+    chris--a/Keypad@3.1.1
+    git+https://github.com/jmparatte/jm_LiquidCrystal_I2C#1.0.0


### PR DESCRIPTION
Some of the versions given as dependency arent available on the new
plattformio registry. Because of that changed the origin to point to the
git source of those modules.
Add prefix/namespace for dependencies from the plattformio registry.